### PR TITLE
Fix home page product display bug

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+$pageTitle = 'AGT Shop — Home';
+
+$db = get_db();
+
+// Fetch featured/latest products
+$stmt = $db->query('SELECT p.id, p.title, p.price_cents, p.thumbnail_path FROM products p WHERE p.is_active = 1 ORDER BY p.created_at DESC LIMIT 12');
+$products = $stmt ? $stmt->fetchAll(PDO::FETCH_ASSOC) : [];
+
+render_header($pageTitle);
+?>
+<main class="container">
+    <section class="hero">
+        <h1>AGT Shop</h1>
+        <p>Buy and sell goods with confidence.</p>
+        <div class="hero-actions">
+            <a class="btn" href="/browse.php">Browse products</a>
+            <?php if (!current_user()): ?>
+                <a class="btn btn-secondary" href="/register.php">Start selling</a>
+            <?php else: ?>
+                <a class="btn btn-secondary" href="/seller/dashboard.php">Seller dashboard</a>
+            <?php endif; ?>
+        </div>
+    </section>
+
+    <section class="grid">
+        <?php foreach ($products as $product): ?>
+            <a class="card" href="/product.php?id=<?php echo (int)$product['id']; ?>">
+                <div class="thumb">
+                    <?php if (!empty($product['thumbnail_path'])): ?>
+                        <img src="<?php echo asset_path($product['thumbnail_path']); ?>" alt="<?php echo h($product['title']); ?>" />
+                    <?php else: ?>
+                        <div class="thumb-placeholder">No image</div>
+                    <?php endif; ?>
+                </div>
+                <div class="card-body">
+                    <h3 class="card-title"><?php echo h($product['title']); ?></h3>
+                    <div class="price"><?php echo format_price((int)$product['price_cents']); ?></div>
+                </div>
+            </a>
+        <?php endforeach; ?>
+        <?php if (empty($products)): ?>
+            <p>No products yet. Be the first to <a href="/register.php">list an item</a>.</p>
+        <?php endif; ?>
+    </section>
+</main>
+<?php render_footer();


### PR DESCRIPTION
Add missing forward slash to `require_once` path in `index.php` to correctly include the bootstrap file.

---
<a href="https://cursor.com/background-agent?bcId=bc-eab82b84-2df3-4981-97bf-acc86875f7fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eab82b84-2df3-4981-97bf-acc86875f7fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

